### PR TITLE
Fix Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -1,7 +1,6 @@
 name: Auto-merge Dependabot PRs
 
-on:
-  pull_request:
+on: pull_request_target
 
 permissions:
   contents: write
@@ -12,14 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     steps:
-      - name: Approve PR
-        run: gh pr review "$PR_URL" --approve --body "Auto-approved: verified Dependabot PR"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Merge PR
-        run: gh pr merge "$PR_URL" --merge
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch' || steps.meta.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- The previous workflow used `on: pull_request`, which forces `GITHUB_TOKEN` to read-only for Dependabot-authored PRs regardless of the `permissions:` block. Jobs never started (zero jobs recorded on every run since 2026-03-30), and every Dependabot PR has been merged manually.
- Switch trigger to `pull_request_target` so the workflow runs in the base-branch context with full declared write permissions.
- Adopt the GitHub-recommended pattern using `dependabot/fetch-metadata@v2` and `gh pr merge --auto`, restricted to patch/minor updates only. Major bumps still require manual review.
- Drop the redundant `gh pr review --approve` step (master is unprotected, no review required; Dependabot can't approve its own PR anyway).

## Test plan
- [ ] Merge this PR.
- [ ] Close and reopen PR #36 (urllib3 2.7.0) to retrigger the updated workflow.
- [ ] Verify the workflow run shows the `auto-merge` job executing (rather than zero jobs).
- [ ] Confirm `gh pr merge --auto` enables auto-merge on PR #36.
- [ ] Confirm the PR merges automatically once any required checks complete.
- [ ] Wait for the next Dependabot PR to land naturally and confirm end-to-end auto-merge works without intervention.

This pull request and its description were written by Isaac.